### PR TITLE
Fix Whisper processors and tokenizer

### DIFF
--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -1948,7 +1948,7 @@ class WhisperTimeStampLogitsProcessor(LogitsProcessor):
     def __init__(
         self,
         generate_config: "GenerationConfig",
-        begin_index: int,
+        begin_index: Optional[int] = None,
         _detect_timestamp_from_logprob: Optional[bool] = None,
     ):  # support for the kwargs
         self.no_timestamps_token_id = generate_config.no_timestamps_token_id
@@ -1961,13 +1961,10 @@ class WhisperTimeStampLogitsProcessor(LogitsProcessor):
             if _detect_timestamp_from_logprob is not None
             else getattr(generate_config, "_detect_timestamp_from_logprob", True)
         )
-        self.begin_index = begin_index
-        if begin_index is None:
-            raise ValueError(
-                "`forced_decoder_ids` is deprecated in favor of `task` and `language` and, as such, `begin_index` "
-                "must be provided to `WhisperTimeStampLogitsProcessor`. The previous default value of `begin_index` "
-                "was `len(generate_config.forced_decoder_ids)`"
-            )
+        num_forced_ids = (
+            len(generate_config.forced_decoder_ids) if generate_config.forced_decoder_ids is not None else 0
+        )
+        self.begin_index = begin_index or (num_forced_ids + 1)
 
         self.max_initial_timestamp_index = getattr(generate_config, "max_initial_timestamp_index", None)
         # TODO(Patrick): Make sure that official models have max_initial_timestamp_index set to 50

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -1344,7 +1344,7 @@ def _split_tokens_on_spaces(tokenizer, tokens: List[int]):
         with_space = subword.startswith(" ")
         punctuation = subword.strip() in "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
 
-        if special or with_space or punctuation or len(words) == 0:
+        if special or with_space or punctuation or len(words) == 0 or words[-1] == " ":
             words.append(subword)
             word_tokens.append(subword_tokens)
             token_indices.append(subword_indices)
@@ -1362,7 +1362,7 @@ def _merge_punctuations(words, tokens, indices, prepended, appended):
     i = len(words) - 2
     j = len(words) - 1
     while i >= 0:
-        if words[i].startswith(" ") and words[i].strip() in prepended:
+        if words[i].startswith(" ") and words[i].strip() in list(prepended):
             words[j] = words[i] + words[j]
             tokens[j] = tokens[i] + tokens[j]
             indices[j] = indices[i] + indices[j]
@@ -1377,7 +1377,7 @@ def _merge_punctuations(words, tokens, indices, prepended, appended):
     i = 0
     j = 1
     while j < len(words):
-        if not words[i].endswith(" ") and words[j] in appended:
+        if not words[i].endswith(" ") and words[j] in list(appended):
             words[i] += words[j]
             tokens[i] += tokens[j]
             indices[i] += indices[j]


### PR DESCRIPTION
## Summary
- update WhisperTimeStampLogitsProcessor to allow optional `begin_index`
- add helper usage in `_merge_punctuations` and `_split_tokens_on_spaces`

## Testing
- `make fixup` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest -k tokenization_whisper -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_6850edac66dc832daca4fc8f82dbd97d